### PR TITLE
Unpin runtime.txt patch version

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.5
+python-3.7


### PR DESCRIPTION
Allows the buildpack to provide any patch version of Python 3.7

Since this hasn't been deployed for a while - just heading off any issues with the buildpack not providing Python 3.7.5